### PR TITLE
fix: Gradle 9.x compatibility - replace removed Convention APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,9 @@ plugins {
 group 'com.ly.smart-doc'
 version '3.1.2'
 
-sourceCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
     mavenLocal() // This is to access the local Maven repository.

--- a/src/main/java/com/ly/doc/gradle/util/ClassLoaderUtil.java
+++ b/src/main/java/com/ly/doc/gradle/util/ClassLoaderUtil.java
@@ -27,7 +27,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
@@ -58,7 +58,7 @@ public class ClassLoaderUtil {
             for (File file : fileSet) {
                 urls.add(file.toURI().toURL());
             }
-            SourceSetContainer ssc = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+            SourceSetContainer ssc = project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
             FileCollection classesDir = ssc.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getClassesDirs();
             Set<File> fileSet1 = classesDir.getFiles();
             for (File file : fileSet1) {


### PR DESCRIPTION
## Summary

Restores build compatibility with **Gradle 8.2+ / 9.x**, which removed the legacy `Convention` APIs. Two removed-API usages were breaking the build:

### 1. `ClassLoaderUtil.java`
`Project.getConvention()` and `JavaPluginConvention` were **removed in Gradle 9**.

```java
// Old (removed in Gradle 9.0)
project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();

// New (available since Gradle 7.1)
project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
```

### 2. `build.gradle`
The project-level `sourceCompatibility` property was provided by the same deprecated convention and is no longer resolvable in Gradle 9 (`Could not set unknown property 'sourceCompatibility'`). Moved it into the `java { }` extension:

```groovy
java {
    sourceCompatibility = JavaVersion.VERSION_1_8
}
```

## Compatibility
`JavaPluginExtension.getSourceSets()` and the `java { }` extension are available since **Gradle 7.1**, so the change works on the project's current Gradle 7.6 wrapper and remains forward-compatible through Gradle 9.x.

## Verification
- `gradle compileJava` -> **BUILD SUCCESSFUL** on Gradle 9.6.1 (previously failed first with `Could not set unknown property 'sourceCompatibility'`, then with the removed `getConvention()` API).
- No functional/behavioral change - identical source set resolution logic.
